### PR TITLE
Fix database and CV rendering issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The former is easier, but I prefer the latter because it allows the database to 
 
 Rendering the CV after building the database requires that LaTeX be installed on your system and available from the command line.  There are various LaTeX distributions depending on your operating system.
 
+_Note: If you get an error that the font Tex Gyre Termes is not installed when executing `render_cv`, you can install it using Homebrew like so:_
+```{bash}
+$ brew tap homebrew/cask-fonts
+$ brew install --cask font-tex-gyre-termes
+```
+
 ### Configuring academicdb
 
 To use academicdb, you must first set up some configuration files, which will reside in `~/.academicdb`.  The most important is `config.toml`, which contains all of the details about you that are used to retrieve your information.  Here are the contents of mine as an example:

--- a/src/academicdb/database.py
+++ b/src/academicdb/database.py
@@ -138,13 +138,14 @@ class MongoDatabase(AbstractDatabase):
     def get_collection(self, collection_name: str, **kwargs):
         # deal with some tables that don't use $set
         testitem = self.client[self.dbname][collection_name].find_one({})
-        if '$set' not in testitem:
-            return list(self.client[self.dbname][collection_name].find({}))
-        else:
-            return [
-                item['$set']
-                for item in self.client[self.dbname][collection_name].find({})
-            ]
+        if testitem is not None:
+            if '$set' not in testitem:
+                return list(self.client[self.dbname][collection_name].find({}))
+            else:
+                return [
+                    item['$set']
+                    for item in self.client[self.dbname][collection_name].find({})
+                ]
 
     def drop_collection(self, collection_name: str, **kwargs):
         self.client[self.dbname].drop_collection(collection_name)

--- a/src/academicdb/orcid.py
+++ b/src/academicdb/orcid.py
@@ -61,7 +61,10 @@ def parse_orcid_affiliation_record(record):
         + record['organization']['address']['region']
     )
     start_date = record['start-date']['year']['value']
-    end_date = record['end-date']['year']['value']
+    if record['end-date'] is not None:
+        end_date = record['end-date']['year']['value']
+    else:
+        end_date = 'present'
     degree = record['role-title']
     dept = record['department-name']
     return [institution, degree, dept, city, start_date, end_date]

--- a/src/academicdb/render_cv.py
+++ b/src/academicdb/render_cv.py
@@ -377,6 +377,15 @@ def main():
     assert len(metadata) == 1, 'There should be only one metadata document'
     metadata = metadata[0]
 
+    parsed_twitter_handle = ""
+    for char in metadata['twitter']:
+        # handle parsing of underscores from twitter handles in latex
+        if char == "_":
+            parsed_twitter_handle += "\char`" + char
+        else:
+            parsed_twitter_handle += char
+    metadata['twitter'] = parsed_twitter_handle
+
     header = pkgutil.get_data('academicdb', 'data/latex_header.tex').decode(
         'utf-8'
     )

--- a/src/academicdb/render_cv.py
+++ b/src/academicdb/render_cv.py
@@ -308,7 +308,7 @@ def get_heading(metadata):
         address += f'{addr_line}\\\\\n'
     heading = f"""
 \\reversemarginpar 
-{{\\LARGE Russell A. Poldrack}}\\\\[4mm] 
+{{\\LARGE {metadata['firstname'].capitalize()} {metadata['middlename'][0].capitalize()}. {metadata['lastname'].capitalize()}}}\\\\[4mm] 
 \\vspace{{-1cm}} 
 
 \\begin{{multicols}}{{2}} 


### PR DESCRIPTION
This PR fixes a few issues that arose when I attempted to build a database and render a CV for the first time.

**Summary**
1. NoneType errors are now handled during database creation if 0 employment records were supplied/found.
2. Education affiliations that are still in progress on ORCiD no longer throw a NoneType error and instead are replaced with "present" for the end date year.
3. Twitter handles that contain underscore `_` symbols threw a `LaTeX` rendering error; the underlying code that parsed the Twitter metadata now modifies the original handle provided by preceding all underscore symbols with the appropriate escape character.
4. Russ' name was hardcoded into the `render_cv` script; I've now replaced this with the Firstname M. Lastname scheme parsed from the user-supplied metadata.
5. A brief note has been added to the `README` explaining to users what they can do if they experience a `LaTeX` related font installation issue.

cheers,
shawn